### PR TITLE
Replace a delete with delete[]

### DIFF
--- a/src/HTTP2_Frame.cc
+++ b/src/HTTP2_Frame.cc
@@ -197,7 +197,7 @@ HTTP2_Data_Frame::HTTP2_Data_Frame(HTTP2_FrameHeader* h, uint8_t* payload, uint3
 HTTP2_Data_Frame::~HTTP2_Data_Frame(void)
 {
     if(this->dataMsg){
-        delete this->dataMsg;
+        delete[] this->dataMsg;
     }
 }
 


### PR DESCRIPTION
Original allocation used new[], so freeing via delete and not delete[]
is undefined behavior.