### PR TITLE
Fix show-plugin btest so the baseline doesn't break with Bro 2.7

### DIFF
--- a/tests/Baseline/http2.show-plugin/output
+++ b/tests/Baseline/http2.show-plugin/output
@@ -1,4 +1,4 @@
-mitrecnd::HTTP2 - Hypertext Transfer Protocol Version 2 analyzer (dynamic, version 0.4)
+mitrecnd::HTTP2 - Hypertext Transfer Protocol Version 2 analyzer (dynamic, version)
     [Analyzer] HTTP2 (ANALYZER_HTTP2, enabled)
     [Event] http2_request
     [Event] http2_reply

--- a/tests/http2/show-plugin.bro
+++ b/tests/http2/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN mitrecnd::HTTP2 >output
+# @TEST-EXEC: bro -NN mitrecnd::HTTP2 |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.
