### PR TITLE
Fix handshake issue

### DIFF
--- a/src/HTTP2.h
+++ b/src/HTTP2.h
@@ -458,6 +458,7 @@ private:
     int64_t maxHeaderListSize;
     uint32_t lastStreams[2];
     uint32_t goAwayStream;
+    std::string serverPreface;
 
     HTTP2_FrameReassembler* reassemblers;
     nghttp2_hd_inflater* inflaters[2];


### PR DESCRIPTION
This is a hack to work around a problem we've been seeing. The analyzer
is currently expecting the client side to start the conversation with
their connection preface (the magic string); it processes others content
only once that has been observed. However, we're seeing sessions where
the *server* is sending the initial messagei, containing their part of
the preface (the SETTINGS). That is getting lost then, and triggering
problems down the road because of settings not being in effect (the max
frame size in particular).

This patch works around this by temporarily buffering the SETTINGS and
then replaying them once the client-side magic has been processed. This
is almost certainly not the best way to fix this, but it avoids a larger
restructure of the handshake code. I figured I'll pass it on for
consideration at least.