### PR TITLE
Make Zeek 5.1 compatible

### DIFF
--- a/src/HTTP2.cc
+++ b/src/HTTP2.cc
@@ -143,7 +143,11 @@ void HTTP2_Analyzer::DeliverStream(int len, const u_char* data, bool orig){
             this->initStreams();
             // Create frame reassemblers which will stitch frames together
             this->initReassemblers();
+#if ZEEK_VERSION_NUMBER >= 40200
+            AnalyzerConfirmation(); // Notify system that this is HTTP2.
+#else // < Zeek 4.2
             ProtocolConfirmation(); // Notify system that this is HTTP2.
+#endif
             DEBUG_INFO("Connection Preface Detected: [%p]!\n", Conn());
         }
     }
@@ -155,7 +159,11 @@ void HTTP2_Analyzer::DeliverStream(int len, const u_char* data, bool orig){
             if(*it == nullptr) {
                 // Reassembler will ensure last frame pointer is null, so no other, valid,
                 // frames should be present that need to be to be handled/deleted
+#if ZEEK_VERSION_NUMBER >= 40200
+                AnalyzerViolation("Unable to parse http 2 frame from data stream, fatal error");
+#else // < Zeek 4.2
                 ProtocolViolation("Unable to parse http 2 frame from data stream, fatal error");
+#endif
                 this->protocol_errored = true;
                 return;
             }


### PR DESCRIPTION
Currently this plugin fails to compile with Zeek 5.1 due to the following error:

    src/HTTP2.cc:146:13: error: ‘ProtocolConfirmation’ was not declared in this scope; did you mean ‘LN_protocolInformation’?
      146 |             ProtocolConfirmation(); // Notify system that this is HTTP2.
          |             ^~~~~~~~~~~~~~~~~~~~
          |             LN_protocolInformation
    src/HTTP2.cc:158:17: error: ‘ProtocolViolation’ was not declared in this scope
      158 |                 ProtocolViolation("Unable to parse http 2 frame from data stream, fatal error");

With Zeek 5.1 ProtocolConfirmation() and ProtocolViolation() have been removed. Since Zeek 4.2 there's AnalyzerConfirmation() and AnalyzerViolation() available.