### PR TITLE
Add guarded zeek-version.h include

### DIFF
--- a/src/HTTP2.cc
+++ b/src/HTTP2.cc
@@ -9,6 +9,11 @@
 #include "debug.h"
 #include "zeek/Reporter.h"
 
+// Ensure ZEEK_VERSION_NUMBER is defined with Zeek 6.0 and later.
+#if __has_include("zeek/zeek-version.h")
+#include "zeek/zeek-version.h"
+#endif
+
 using namespace analyzer::mitrecnd;
 
 const bool DEBUG_http2 = true;


### PR DESCRIPTION
ZEEK_VERSION_NUMBER may not be defined when this plugin is included as a builtin plugin, explicitly include zeek/zeek-version.h when available.

A bit of background is here:
https://github.com/zeek/zeek/issues/2806

When using bro-http2 as a builtin plugin (`--include-plugins`) currently ZEEK_VERSION_NUMBER is not defined. This should change before Zeek 6.0, but it's also better practice to directly include the required header.