### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project(ZeekPluginHTTP2)
 


### PR DESCRIPTION
The just released [Zeek 6.1.0](https://github.com/zeek/zeek/releases/tag/v6.1.0) now requires plugins to have a required minimum CMake version of at least 3.15.  This updates CMakeLists.txt to reflect this new requirement.